### PR TITLE
Ignore include directives

### DIFF
--- a/__tests__/extract.test.ts
+++ b/__tests__/extract.test.ts
@@ -309,4 +309,8 @@ ifdef::revnumber[Asciidoc looks for the last ] in the string]
     expect(extract(document, options)).toEqual([]);
   });
 
+  it('ignores include::...[]', () => {
+    const document = adoc('include::bar.adoc[]\n');
+    expect(extract(document, options)).toEqual([]);
+  });
 });

--- a/includes.ts
+++ b/includes.ts
@@ -1,0 +1,16 @@
+import IncludeProcessor = AsciiDoctorJs.IncludeProcessor;
+
+// NOTE: this is a 'no-op' include processor. reader.push_include() is not
+// called at all, so nothing is actually included. The rationale is that it's
+// probably a better idea to gettextize each .adoc separately, so that one .pot
+// is created for each .adoc. That way, if an .adoc is included in multiple
+// places, the strings from the included .adoc only need to be translated once.
+
+export function includeProcessor(this: IncludeProcessor) {
+  this.process((document, reader, target, attributes) => {
+    // tslint:disable-next-line:no-empty
+  });
+  this.handles((target) => {
+    return true;
+  });
+}

--- a/singleton.ts
+++ b/singleton.ts
@@ -1,8 +1,10 @@
 import AsciiDoctorFactory from 'asciidoctor.js';
+import { includeProcessor } from './includes';
 import { preprocessor } from './conditionals';
 
 export const asciidoctor = AsciiDoctorFactory();
 
 asciidoctor.Extensions.register(function() {
   this.preprocessor(preprocessor);
+  this.includeProcessor(includeProcessor);
 });

--- a/types/asciidoctor.d.ts
+++ b/types/asciidoctor.d.ts
@@ -10,6 +10,11 @@ declare namespace AsciiDoctorJs {
     process(callback: (document: Document, reader: PreproccesorReader) => void): void;
   }
 
+  export class IncludeProcessor {
+    handles(callback: (target: string) => boolean): void;
+    process(callback: (document: Document, reader: PreproccesorReader, target: string, attributes: Attributes) => void): void;
+  }
+
   export interface Parser {
 
   }
@@ -77,6 +82,7 @@ declare namespace AsciiDoctorJs {
 
   export interface Registry {
     treeProcessor(callback: (this: TreeProcessor) => void): void;
+    includeProcessor(callback: (this: IncludeProcessor) => void): void;
     preprocessor(callback: (this: Preprocessor) => void): void;
   }
 


### PR DESCRIPTION
This adds a 'no-op' include processor. `reader.push_include()` is not
called at all, so nothing is actually included. The rationale is that it's
probably a better idea to gettextize each `.adoc` separately, so that one `.pot`
is created for each `.adoc`. That way, if an `.adoc` is included in multiple
places, the strings from the included `.adoc` only need to be translated once.