### PR TITLE
Enable defining attribute values with gettextize

### DIFF
--- a/__tests__/fixture.adoc
+++ b/__tests__/fixture.adoc
@@ -4,3 +4,5 @@
 
 Consectetuer adipiscing elit. Aenean commodo ligula eget dolor.
 Aenean massa.
+
+include::{var1}/{var2}/bar.adoc[]

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -85,5 +85,33 @@ Invalid regular expression: /(/: Unterminated group`);
       expect(ret.stdout).not.toMatch('Consectetuer');
       expect(ret.stdout).toMatch('Aenean massa.');
     });
+    it('fails for invalid attribute', () => {
+      const ret = run([
+        'gettextize', '-m', fixture,
+        '-a', 'var1',
+      ]);
+      expect(ret.status).toEqual(1);
+      expect(ret.stderr).toMatch('Error in --attribute');
+    });
+    it('fails for missing attribute name', () => {
+      const ret = run([
+        'gettextize', '-m', fixture,
+        '-a', '=value',
+      ]);
+      expect(ret.status).toEqual(1);
+      expect(ret.stderr).toMatch('Error in --attribute');
+    });
+    it('can pass variables', () => {
+      const ret = run([
+        'gettextize', '-m', fixture,
+        '-a', 'var1=abc',
+        '--attribute', 'var2=xyz',
+      ]);
+      expect(ret.status).toEqual(0);
+      // The fixture contains an include directive that contains attributes.
+      // If the attributes are not properly set, a "Unresolved directive ..."
+      // message is emitted in the output.
+      expect(ret.stdout).not.toMatch('Unresolved directive');
+    });
   });
 });


### PR DESCRIPTION
If attributes are used in `include::...[]` directives, the attributes need to be defined to avoid getting "Unresolved directive..." messages emitted in the parsed Document...